### PR TITLE
Fix issue that when a choice was deleted, ratings were not deleted

### DIFF
--- a/src/components/ratings/Rating.js
+++ b/src/components/ratings/Rating.js
@@ -43,7 +43,12 @@ export const Rating = ({ factor, option, choice }) => {
     <td
       onClick={(clickEvent) => {
         setModalContent(
-          <RatingDetail rating={rating} factor={factor} option={option} />
+          <RatingDetail
+            rating={rating}
+            factor={factor}
+            option={option}
+            choice={choice}
+          />
         );
         handleShow();
       }}

--- a/src/components/ratings/RatingDetail.js
+++ b/src/components/ratings/RatingDetail.js
@@ -51,6 +51,7 @@ export const RatingDetail = (props) => {
               : addRating({
                   factorId: props.factor.id,
                   optionId: props.option.id,
+                  choiceId: props.choice.id,
                   score: parseInt(rating.score),
                 });
             handleClose();


### PR DESCRIPTION
Problem: When a choice was deleted, the associated ratings were not deleted, since json-server only scans the database once to remove items with an invalid foreign key.

Solution: 
1. Added the choiceId as a foreign key to the ratings