### PR TITLE
Grey out used weights

### DIFF
--- a/src/components/weights/WeightWallet.js
+++ b/src/components/weights/WeightWallet.js
@@ -35,6 +35,8 @@ export const WeightWallet = (props) => {
         style={{
           backgroundColor: "lightgrey",
           filter: "grayscale(100%)",
+          padding: "3px 0px",
+          borderRadius: "4px",
         }}
       >
         {IntToWeight(props.weightsUsed, props.choice)}

--- a/src/components/weights/WeightWallet.js
+++ b/src/components/weights/WeightWallet.js
@@ -30,7 +30,12 @@ export const WeightWallet = (props) => {
     <div className="weight__wallet">
       <div>Weight Wallet</div>
       <WeightList {...props} />
-      <span style={{ backgroundColor: "lightgrey" }}>
+      <span
+        style={{
+          backgroundColor: "lightgrey",
+          filter: "grayscale(100%)",
+        }}
+      >
         {IntToWeight(props.weightsUsed, props.choice)}
       </span>
       <span style={{ color: "darkslategrey" }}>

--- a/src/components/weights/WeightWallet.js
+++ b/src/components/weights/WeightWallet.js
@@ -29,6 +29,7 @@ export const WeightWallet = (props) => {
   return (
     <div className="weight__wallet">
       <div>Weight Wallet</div>
+      <div> Weights used: {props.weightsUsed}</div>
       <WeightList {...props} />
       <span
         style={{


### PR DESCRIPTION
User feedback indicated that it wasn't clear when weights were being consumed from the weight wallet.
To solve this, the used weights are now shown in grey, and there is a count, indicating how many weights have been used.
